### PR TITLE
Support holes in arguments of join implementations

### DIFF
--- a/src/Dictionary/join.lua
+++ b/src/Dictionary/join.lua
@@ -7,11 +7,13 @@ local function join(...)
 	for dictionaryIndex = 1, select("#", ...) do
 		local dictionary = select(dictionaryIndex, ...)
 
-		for k, v in pairs(dictionary) do
-			if v == None then
-				new[k] = nil
-			else
-				new[k] = v
+		if dictionary then
+			for k, v in pairs(dictionary) do
+				if v == None then
+					new[k] = nil
+				else
+					new[k] = v
+				end
 			end
 		end
 	end

--- a/src/Dictionary/joinDeep.lua
+++ b/src/Dictionary/joinDeep.lua
@@ -8,17 +8,19 @@ local function joinDeep(...)
 	for dictionaryIndex = 1, select("#", ...) do
 		local dictionary = select(dictionaryIndex, ...)
 
-		for k, v in pairs(dictionary) do
-			if v == None then
-				new[k] = nil
-			elseif type(v) == "table" then
-				if new[k] == nil or type(new[k] ~= "table") then
-					new[k] = copyDeep(v)
+		if dictionary then
+			for k, v in pairs(dictionary) do
+				if v == None then
+					new[k] = nil
+				elseif type(v) == "table" then
+					if new[k] == nil or type(new[k] ~= "table") then
+						new[k] = copyDeep(v)
+					else
+						new[k] = joinDeep(new[k], v)
+					end
 				else
-					new[k] = joinDeep(new[k], v)
+					new[k] = v
 				end
-			else
-				new[k] = v
 			end
 		end
 	end

--- a/src/List/join.lua
+++ b/src/List/join.lua
@@ -9,10 +9,12 @@ local function join(...)
 	for listIndex = 1, select("#", ...) do
 		local list = select(listIndex, ...)
 
-		for i = 1, #list do
-			if list[i] ~= None then
-				new[index] = list[i]
-				index = index + 1
+		if list then
+			for i = 1, #list do
+				if list[i] ~= None then
+					new[index] = list[i]
+					index = index + 1
+				end
 			end
 		end
 	end

--- a/src/List/joinDeep.lua
+++ b/src/List/joinDeep.lua
@@ -10,18 +10,20 @@ local function joinDeep(...)
 	for listIndex = 1, select("#", ...) do
 		local list = select(listIndex, ...)
 
-		for i = 1, #list do
-			if type(list[i]) == "table" then
-				if new[index] == nil or type(new[index] ~= "table") then
-					new[index] = copyDeep(list[i])
-				else
-					new[index] = joinDeep(new[index], list[i])
+		if list then
+			for i = 1, #list do
+				if type(list[i]) == "table" then
+					if new[index] == nil or type(new[index] ~= "table") then
+						new[index] = copyDeep(list[i])
+					else
+						new[index] = joinDeep(new[index], list[i])
+					end
+				elseif list[i] ~= None then
+					new[index] = list[i]
 				end
-			elseif list[i] ~= None then
-				new[index] = list[i]
-			end
 
-			index = index + 1
+				index = index + 1
+			end
 		end
 	end
 

--- a/tests/Llama/Dictionary/join.spec.lua
+++ b/tests/Llama/Dictionary/join.spec.lua
@@ -98,4 +98,24 @@ return function()
 	it("should accept zero tables", function()
 		expect(join()).to.be.a("table")
 	end)
+
+	it("should accept holes in arguments", function()
+		local a = {
+			foo = "foo-a",
+		}
+
+		local b = {
+			bar = "bar-b",
+		}
+
+		local c = join(a, nil, b)
+
+		expect(c.foo).to.equal(a.foo)
+		expect(c.bar).to.equal(b.bar)
+
+		local d = join(nil, a, b)
+
+		expect(d.foo).to.equal(a.foo)
+		expect(d.bar).to.equal(b.bar)
+	end)
 end

--- a/tests/Llama/List/join.spec.lua
+++ b/tests/Llama/List/join.spec.lua
@@ -51,7 +51,7 @@ return function()
 
 	it("should accept holes in arguments", function()
 		local a = {1}
-		local b = {1}
+		local b = {2}
 
 		local c = join(a, nil, b)
 

--- a/tests/Llama/List/join.spec.lua
+++ b/tests/Llama/List/join.spec.lua
@@ -48,4 +48,21 @@ return function()
 	it("should accept zero tables", function()
 		expect(join()).to.be.a("table")
 	end)
+
+	it("should accept holes in arguments", function()
+		local a = {1}
+		local b = {1}
+
+		local c = join(a, nil, b)
+
+		expect(#c).to.equal(2)
+		expect(c[1]).to.equal(1)
+		expect(c[2]).to.equal(2)
+
+		local d = join(nil, a, b)
+
+		expect(#d).to.equal(2)
+		expect(d[1]).to.equal(1)
+		expect(d[2]).to.equal(2)
+	end)
 end


### PR DESCRIPTION
Fixes issue with `Llama.Dictionary.join(nil, a, b)`