### PR TITLE
Add findKey function

### DIFF
--- a/src/Dictionary/findKey.lua
+++ b/src/Dictionary/findKey.lua
@@ -1,0 +1,26 @@
+local Dictionary = script.Parent
+
+local Llama = Dictionary.Parent
+local t = require(Llama.t)
+
+local function alwaysTrue()
+	return true
+end
+
+local validate = t.table
+
+local function findKey(dictionary, value, predicate)
+	assert(validate(dictionary))
+
+	predicate = predicate or alwaysTrue
+	
+	for k, v in pairs(dictionary) do
+		if v == value and predicate(k) then
+			return k
+		end
+	end
+
+	return nil
+end
+
+return findKey

--- a/src/Dictionary/init.lua
+++ b/src/Dictionary/init.lua
@@ -11,6 +11,7 @@ local Dictionary = {
 	fromLists = require(script.fromLists),
 	has = require(script.has),
 	includes = require(script.includes),
+	findKey = require(script.findKey),
 	join = require(script.merge),
 	joinDeep = require(script.mergeDeep),
 	keys = require(script.keys),

--- a/tests/Llama/Dictionary/findKey.spec.lua
+++ b/tests/Llama/Dictionary/findKey.spec.lua
@@ -1,0 +1,59 @@
+return function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+	local Packages = ReplicatedStorage.Packages
+	local Llama = require(Packages.Llama)
+
+	local Dictionary = Llama.Dictionary
+	local findKey = Dictionary.findKey
+
+	it("should validate types", function()
+		local args = {
+			{ 0 },
+			{ 0, 0 },
+		}
+
+		for i = 1, #args do
+			local _, err = pcall(function()
+				findKey(unpack(args[i]))
+			end)
+
+			expect(string.find(err, "expected, got")).to.be.ok()
+		end
+	end)
+
+	it("should return the key that the value is matched to or nil", function()
+		local a = {
+			foo = "oof",
+			bar = "rab",
+			baz = "zab"
+		}
+
+		expect(findKey(a, "oof")).to.equal("foo")
+		expect(findKey(a, "foo")).to.equal(nil)
+	end)
+
+	it("should honor the predicate", function()
+		local a = {
+			foo = "oof",
+			bar = "oof",
+			baz = "oof"
+		}
+
+		expect(findKey(a, "oof", function(key)
+			return key ~= "foo" and key ~= "bar"
+		end)).to.equal("baz")
+	end)
+
+	it("should return nil when the predicate is not met", function()
+		local a = {
+			foo = "oof",
+			bar = "oof",
+			baz = "oof"
+		}
+
+		expect(findKey(a, "oof", function(key)
+			return key ~= "foo" and key ~= "bar" and key ~= "baz"
+		end)).to.equal(nil)
+	end)
+end


### PR DESCRIPTION
This PR adds a `findKey` function. It behaves very similarily to the `includes` function except that it returns the key that was found when matching the value as opposed to a boolean.

This is a similar dictionary equivalent to the `find` function for lists.