### PR TITLE
Fix references to old GitHub username

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">📚 Llama 🦙</h1>
 <div align="center">
-	<a href="https://github.com/Frelerik/llama/actions"><img src="https://github.com/Frelerik/llama/workflows/CI/badge.svg" alt="GitHub Actions Build Status" /></a>
-	<a href="https://frelerik.github.io/llama"><img src="https://img.shields.io/badge/docs-website-green.svg" alt="Documentation" /></a>
+	<a href="https://github.com/Freddylist/llama/actions"><img src="https://github.com/Freddylist/llama/workflows/CI/badge.svg" alt="GitHub Actions Build Status" /></a>
+	<a href="https://freddylist.github.io/llama"><img src="https://img.shields.io/badge/docs-website-green.svg" alt="Documentation" /></a>
 </div>
 <div align="center">
 	Lua Library for Immutable Data
@@ -70,12 +70,12 @@ local function reducer(state, action)
 end
 ```
 
-Visit the [docs](https://frelerik.github.io/llama/) for examples and API reference.
+Visit the [docs](https://freddylist.github.io/llama/) for examples and API reference.
 
 ## Special Thanks
 
 - [Mathilde](https://www.instagram.com/httpsugars_/) for the Llama icon
-- [Llama's contributors](https://github.com/Frelerik/llama/graphs/contributors)
+- [Llama's contributors](https://github.com/Freddylist/llama/graphs/contributors)
 
 ## What's in a name?
 Llamas are members of the Camelid group of mammals along with alpacas, camels, and dromedaries, which are known for being very stubborn but reliable animals.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">📚 Llama 🦙</h1>
 <div align="center">
-	<a href="https://github.com/Freddylist/llama/actions"><img src="https://github.com/Freddylist/llama/workflows/CI/badge.svg" alt="GitHub Actions Build Status" /></a>
+	<a href="https://github.com/freddylist/llama/actions"><img src="https://github.com/freddylist/llama/workflows/CI/badge.svg" alt="GitHub Actions Build Status" /></a>
 	<a href="https://freddylist.github.io/llama"><img src="https://img.shields.io/badge/docs-website-green.svg" alt="Documentation" /></a>
 </div>
 <div align="center">
@@ -75,7 +75,7 @@ Visit the [docs](https://freddylist.github.io/llama/) for examples and API refer
 ## Special Thanks
 
 - [Mathilde](https://www.instagram.com/httpsugars_/) for the Llama icon
-- [Llama's contributors](https://github.com/Freddylist/llama/graphs/contributors)
+- [Llama's contributors](https://github.com/freddylist/llama/graphs/contributors)
 
 ## What's in a name?
 Llamas are members of the Camelid group of mammals along with alpacas, camels, and dromedaries, which are known for being very stubborn but reliable animals.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Llama
-site_url: https://frelerik.github.io/llama/
-repo_name: Frelerik/llama
-repo_url: https://github.com/Frelerik/llama
+site_url: https://freddylist.github.io/llama/
+repo_name: Freddylist/llama
+repo_url: https://github.com/Freddylist/llama
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Llama
 site_url: https://freddylist.github.io/llama/
-repo_name: Freddylist/llama
-repo_url: https://github.com/Freddylist/llama
+repo_name: freddylist/llama
+repo_url: https://github.com/freddylist/llama
 
 theme:
   name: material

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama"
-author = "Frelerik"
+author = "Freddylist"
 content_root = "src"
 version = "1.1.0"
 license = "MIT"

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama"
-author = "Freddylist"
+author = "freddylist"
 content_root = "src"
 version = "1.1.0"
 license = "MIT"


### PR DESCRIPTION
Recently the repository owner changed their username from `frelerik` to `freddylist`, which broke the Documentation and created a redirection for package managers to fetch the appropriate package.