### PR TITLE
Fix example in docs for filter

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -306,7 +306,7 @@ filterer(value, key) -> result
 local dictionary = {
 	foo1 = "foo",
 	foo2 = "foo",
-	bar = "foo",
+	bar1 = "bar",
 }
 
 local function onlyFoo(value)


### PR DESCRIPTION
Right now, the code example for the filter function is incorrect. When writing, the author may have accidentally mixed up what the function does with key and value.