### PR TITLE
Add Wally support

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,5 @@
+[package]
+name = "freddylist/llama"
+version = "1.1.0"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"

--- a/wally.toml
+++ b/wally.toml
@@ -3,3 +3,4 @@ name = "freddylist/llama"
 version = "1.1.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
+include = ["default.project.json", "src"]

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,9 @@
 [package]
 name = "freddylist/llama"
+description = "Luau Library for Immutable Data"
 version = "1.1.0"
-registry = "https://github.com/UpliftGames/wally-index"
+license = "MIT"
+authors = ["Frederik List <51757856+freddylist@users.noreply.github.com>"]
 realm = "shared"
+registry = "https://github.com/UpliftGames/wally-index"
 include = ["default.project.json", "src"]


### PR DESCRIPTION
This pull request adds Wally support.

# Getting your package on the Wally registry

- Install Wally into your PATH from the [latest GitHub release](https://github.com/UpliftGames/wally/releases)
- Navigate into this project folder with the terminal of your choice
- Run `wally login` and follow the instructions given
- Run `wally install`